### PR TITLE
Buff goddess of the hunt (add +1 faith)

### DIFF
--- a/NQMP/NQMP/religion/PantheonChanges.xml
+++ b/NQMP/NQMP/religion/PantheonChanges.xml
@@ -253,6 +253,37 @@
 		</Row>
 	</Language_RU_RU>
 
+	<!-- Goddess of the Hunt: Camps give +1 faith +1 food (instead of +1 food from camps) -->
+	<Belief_ImprovementYieldChanges>
+		<Update>
+			<Set Yield="1" />
+			<Where BeliefType="BELIEF_GODDESS_HUNT" ImprovementType="IMPROVEMENT_CAMP" YieldType="YIELD_FAITH" />
+		</Update>
+	</Belief_ImprovementYieldChanges>
+	<Language_en_US>
+		<Delete Tag="TXT_KEY_BELIEF_GODDESS_HUNT" />
+		<Row Tag="TXT_KEY_BELIEF_GODDESS_HUNT">
+			<Text>+1 [ICON_FOOD] Food and +1 [ICON_PEACE] Faith from camps</Text>
+		</Row>
+	</Language_en_US>
+	<Language_DE_DE>
+		<Delete Tag="TXT_KEY_BELIEF_GODDESS_HUNT" />
+		<Row Tag="TXT_KEY_BELIEF_GODDESS_HUNT">
+			<Text>[COLOR_WARNING_TEXT](DE_DE text) [ENDCOLOR]+1 [ICON_FOOD] Food and +1 [ICON_PEACE] Faith from camps</Text>
+		</Row>
+	</Language_DE_DE>
+	<Language_PL_PL>
+		<Delete Tag="TXT_KEY_BELIEF_GODDESS_HUNT" />
+		<Row Tag="TXT_KEY_BELIEF_GODDESS_HUNT">
+			<Text>[COLOR_WARNING_TEXT](PL_PL text) [ENDCOLOR]+1 [ICON_FOOD] Food and +1 [ICON_PEACE] Faith from camps</Text>
+		</Row>
+	</Language_PL_PL>
+	<Language_RU_RU>
+		<Delete Tag="TXT_KEY_BELIEF_GODDESS_HUNT" />
+		<Row Tag="TXT_KEY_BELIEF_GODDESS_HUNT">
+			<Text>[COLOR_WARNING_TEXT](RU_RU text) [ENDCOLOR]+1 [ICON_FOOD] Food and +1 [ICON_PEACE] Faith from camps</Text>
+		</Row>
+	</Language_RU_RU>
 
 	<!-- Goddess of Love: Population requirement reduced to 4+ (from 6+) -->
 	<Beliefs>


### PR DESCRIPTION
Currently there are no viable camp/truffle pantheons. This is just a small buff to goddess of the hunt to make it a potentially useful pantheon as you can get a religion with it now. Currently it's clearly worse than similar pantheons (e.g. plantation culture).

Another possible buff would be to make it like sun god (+1 food from camp resources) while not requiring a camp to be built